### PR TITLE
feat: use get method instead of post so we can share links

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,9 +27,15 @@ app.get("/", (req, res) => {
     });
 });
 
-// main route (post)
+// redirect post requests to get
 app.post("/", async (req, res) => {
-    const userid = req.body.user;
+    if(req.body.user) res.redirect(`/${req.body.user}`);
+    else res.redirect("/404");
+});
+
+// main route (get)
+app.get("/:userID", async (req, res) => {
+    const userid = req.params.userID;
     if (!userid) return res.redirect("/404");
 
     // fetch user


### PR DESCRIPTION
Use get method instead of post, so we can share links like https://user.x-bot.fr/83010416610906112 (this can't be done using POST requests).