### PR TITLE
fix token regex

### DIFF
--- a/server.js
+++ b/server.js
@@ -95,7 +95,7 @@ app.listen(PORT, () => {
 
 // resolve user id
 function getID(source) {
-    const tokenRegex = /([MN][A-Za-z\d]{23})\.([\w-]{6})\.([\w-]{27})/,
+    const tokenRegex = /([A-Za-z\d]{24})\.([\w-]{6})\.([\w-]{27})/,
         isToken = tokenRegex.test(source);
     if (isToken) {
         const base64 = source.split(".")[0];


### PR DESCRIPTION
Certains tokens commencent par un O maintenant (et plus ça ira, plus on va se décaler dans l'alphabet donc autant enlever la vérification de la 1ère lettre)